### PR TITLE
[VOICE-45] ⚰ chore: Add credentials directory to gitignore for security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+VOICE_STT Server/credentials/


### PR DESCRIPTION
[VOICE-45] chore: Add credentials directory to gitignore for security

Changes:
- Add VOICE_STT Server/credentials/ to .gitignore
- Remove service_account.json from git tracking for security

Resolves VOICE-45

[VOICE-45]: https://csevoice.atlassian.net/browse/VOICE-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ